### PR TITLE
13 & 14 view and access real data

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,3 +1,4 @@
 fbs==0.8.4
 PyQt5==5.13.2
 git+https://github.com/alleninstitute/ipfx
+pyqtgraph==0.10.0

--- a/src/main/python/delegates.py
+++ b/src/main/python/delegates.py
@@ -62,7 +62,7 @@ class ComboBoxDelegate(QItemDelegate):
 
     def setModelData(self, editor, model, index):
         value = editor.currentText()
-        model.setData(index, QtCore.Qt.DisplayRole, QtCore.QVariant(value))
+        model.setData(index, value, QtCore.Qt.EditRole)
 
     def updateEditorGeometry(self, editor, option, index):
         editor.setGeometry(option.rect)

--- a/src/main/python/main.py
+++ b/src/main/python/main.py
@@ -38,7 +38,6 @@ class SweepPage(QWidget):
         self.sweep_model = SweepTableModel(self.colnames)
 
         self.sweep_view.setModel(self.sweep_model)
-        self.sweep_view.open_persistent_editor_on_column(self.colnames.index("manual QC state"))
 
         layout = QVBoxLayout()
         layout.addWidget(self.sweep_view)

--- a/src/main/python/main.py
+++ b/src/main/python/main.py
@@ -32,6 +32,10 @@ class SweepPage(QWidget):
     )
 
     def __init__(self):
+        """ Holds and displays a table view (and associated model) containing 
+        information about individual sweeps. 
+        """
+
         super().__init__()
 
         self.sweep_view = SweepTableView(self.colnames)
@@ -46,7 +50,16 @@ class SweepPage(QWidget):
         self.sweep_view.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
         self.sweep_view.verticalHeader().setSectionResizeMode(QHeaderView.Stretch)
 
-    def connect_model(self, data: PreFxData):
+    def connect(self, data: PreFxData):
+        """ Attach this component to others via signals and slots
+
+        Parameters
+        ----------
+        data : 
+            Will be used as the underlying data store (via this object's model).
+
+        """
+
         self.sweep_model.connect(data)
 
 
@@ -92,13 +105,39 @@ class MainWindow(QMainWindow):
         self.setCentralWidget(tab_widget)
 
 
-    def insert_tabs(self, sweep_page, feature_page, plot_page):
+    def insert_tabs(
+        self, 
+        sweep_page: SweepPage, 
+        feature_page: FeaturePage, 
+        plot_page: PlotPage
+    ):
+        """ Setup tabs for this window's central viewport.
+
+        Parameters
+        ----------
+        sweep_page : 
+            Displays a table of sweeps and allows users to enter manual QC values.
+        feature_page : 
+            Displays a table of cell-scale features.
+        plot_page : 
+            Displays plots which describe the cell's response to various stimulus categories.
+
+        """
+
         self.centralWidget().insertTab(0, sweep_page, "Sweeps")
         self.centralWidget().insertTab(1, feature_page, "Features")
         self.centralWidget().insertTab(2, plot_page, "Plots")
 
 
     def create_main_menu_bar(self, pre_fx_controller: PreFxController):
+        """ Set up the main application menu.
+
+        Parameters
+        ----------
+        pre_fx_controller : 
+            Owns QActions for loading nwb data, stimulus ontologies, and qc criteria
+
+        """
 
         self.main_menu_bar = self.menuBar()
         self.file_menu = self.main_menu_bar.addMenu("File")
@@ -144,7 +183,7 @@ class Application(object):
 
         # connect components
         self.pre_fx_controller.connect(self.pre_fx_data)
-        self.sweep_page.connect_model(self.pre_fx_data)
+        self.sweep_page.connect(self.pre_fx_data)
         self.main_window.insert_tabs(self.sweep_page, self.feature_page, self.plot_page)
         self.main_window.create_main_menu_bar(self.pre_fx_controller)
 

--- a/src/main/python/pre_fx_data.py
+++ b/src/main/python/pre_fx_data.py
@@ -27,7 +27,7 @@ class PreFxData(QObject):
     qc_criteria_unset = pyqtSignal(name="qc_criteria_unset")
 
     begin_commit_calculated = pyqtSignal(name="begin_commit_calculated")
-    end_commit_calculated = pyqtSignal(list, list, EphysDataSet, name="end_commit_calculated")
+    end_commit_calculated = pyqtSignal(list, list, dict, EphysDataSet, name="end_commit_calculated")
 
     def __init__(self):
         """ Main data store for all data upstream of feature extraction. This
@@ -44,6 +44,7 @@ class PreFxData(QObject):
         self._qc_criteria: Optional[Dict] = None
         self.data_set: Optional[EphysDataSet] = None
         self.nwb_path: Optional[str] = None
+        self.manual_qc_states: Dict[int, str] = {}
 
     def _notifying_setter(
         self, 
@@ -286,10 +287,14 @@ class PreFxData(QObject):
 
             self.sweep_features = sweep_features
             self.sweep_states = sweep_states
+            self.manual_qc_states = {sweep["sweep_number"]: "None" for sweep in self.sweep_features}
 
             self.end_commit_calculated.emit(
-                self.sweep_features, self.sweep_states, self.data_set
+                self.sweep_features, self.sweep_states, self.manual_qc_states, self.data_set
             )
+
+    def on_manual_qc_state_updated(self, sweep_number: int, new_state: str):
+        self.manual_qc_states[sweep_number] = new_state
 
 
 def extract_qc_features(data_set):

--- a/src/main/python/pre_fx_data.py
+++ b/src/main/python/pre_fx_data.py
@@ -218,15 +218,11 @@ class PreFxData(QObject):
 
         return [
             {
-                "sweep_number": 25,
-                "sweep_state": "failed"
-            },
-            {
-                "sweep_number": 26,
-                "sweep_state": "failed"
-            },
-
-               ]
+                "sweep_number": sweep["sweep_number"],
+                "sweep_state": self.manual_qc_states[sweep["sweep_number"]]
+            }
+            for sweep in self.sweep_features
+        ]
 
     def save_manual_states_to_json(self, filepath: str):
 
@@ -287,7 +283,7 @@ class PreFxData(QObject):
 
             self.sweep_features = sweep_features
             self.sweep_states = sweep_states
-            self.manual_qc_states = {sweep["sweep_number"]: "None" for sweep in self.sweep_features}
+            self.manual_qc_states = {sweep["sweep_number"]: "default" for sweep in self.sweep_features}
 
             self.end_commit_calculated.emit(
                 self.sweep_features, self.sweep_states, self.manual_qc_states, self.data_set

--- a/src/main/python/pre_fx_data.py
+++ b/src/main/python/pre_fx_data.py
@@ -27,7 +27,7 @@ class PreFxData(QObject):
     qc_criteria_unset = pyqtSignal(name="qc_criteria_unset")
 
     begin_commit_calculated = pyqtSignal(name="begin_commit_calculated")
-    end_commit_calculated = pyqtSignal(name="end_commit_calculated")
+    end_commit_calculated = pyqtSignal(list, list, EphysDataSet, name="end_commit_calculated")
 
     def __init__(self):
         """ Main data store for all data upstream of feature extraction. This
@@ -287,7 +287,9 @@ class PreFxData(QObject):
             self.sweep_features = sweep_features
             self.sweep_states = sweep_states
 
-            self.end_commit_calculated.emit()
+            self.end_commit_calculated.emit(
+                self.sweep_features, self.sweep_states, self.data_set
+            )
 
 
 def extract_qc_features(data_set):

--- a/src/main/python/sweep.py
+++ b/src/main/python/sweep.py
@@ -10,30 +10,64 @@ from PyQt5 import QtCore
 
 import numpy as np
 import matplotlib.pyplot as plt
+from scipy.signal import bessel, filtfilt
+
+from ipfx.epochs import get_experiment_epoch
 
 from delegates import (SvgDelegate, ComboBoxDelegate)
+from pre_fx_data import PreFxData
 
 
 class SweepTableModel(QAbstractTableModel):
     def __init__(self, colnames):
         super().__init__()
         self.colnames = colnames
+        self._data = []
 
-    def get_data(self, data=None):
+    
+    def connect(self, data: PreFxData):
+        data.end_commit_calculated.connect(self.on_new_data)
 
-        if data:
-            self._data = data
-        else:
-            self._data = [
-                [1, "abs0", "Long Square", "passed", "default", None],
-                [3, "abs1", "Long Square", "passed", "default", None],
-                [7, "abs2", "Short Square", "failed", "default", "Vm above threshold, Noise above threshold"],
-                [13, "abs3", "Ramp", "passed", "default", None],
-            ]
 
-        for item in self._data:
-            item.append(tmp_mpl_svg(item[0]))
-            item.append(tmp_mpl_svg(item[0]))
+    def on_new_data(self, sweep_features, sweep_states, dataset):
+        self.beginRemoveRows(QModelIndex(), 1, self.rowCount())
+        self._data = []
+        self.endRemoveRows()
+
+        state_lookup = {state["sweep_number"]: state for state in sweep_states}
+        bessel_num, bessel_denom = bessel(4, 0.1, "low")
+
+        previous_test_voltage = None
+        initial_test_voltage = None
+
+        self.beginInsertRows(QModelIndex(), 1, len(sweep_features))
+        for sweep in sorted(sweep_features, key=lambda swp: swp["sweep_number"]):
+            sweep_number = sweep["sweep_number"]
+            state = state_lookup[sweep_number]
+
+            sweep_data = dataset.sweep(sweep_number)
+            test_time, test_voltage = test_response_plot_data(sweep_data)
+            exp_time, exp_voltage, exp_baseline = experiment_plot_data(
+                sweep_data, bessel_num, bessel_denom
+            )
+
+            test_pulse_plot = make_test_pulse_plot(sweep_number, test_time, 
+                test_voltage, previous_test_voltage, initial_test_voltage
+            )
+            experiment_plot = make_experiment_plot(exp_time, exp_voltage, exp_baseline)
+
+            self._data.append([
+                sweep_number,
+                sweep["stimulus_code"],
+                sweep["stimulus_name"],  # stimulus type
+                state["passed"] and sweep["passed"], # auto qc
+                "None", # manual qc
+                sweep["tags"] + state["reasons"], # fail tags
+                svg_from_mpl_axes(test_pulse_plot),
+                svg_from_mpl_axes(experiment_plot)
+            ])
+
+        self.endInsertRows()
 
     def rowCount(self, parent=None, *args, **kwargs):
         """ Returns the number of rows under the given parent. When the parent
@@ -127,7 +161,7 @@ def tmp_mpl_svg(ct=1):
     ex = np.linspace(0, ct * np.pi, 100000)
     why = np.cos(ex)
 
-    _, ax = plt.subplots()
+    fig, ax = plt.subplots()
 
     ax.plot(ex, why)
 
@@ -137,3 +171,61 @@ def tmp_mpl_svg(ct=1):
 
 
     return QByteArray(data.getvalue())
+
+
+def svg_from_mpl_axes(fig):
+    data = io.BytesIO()
+    plt.savefig(data, format="svg")
+    plt.close(fig)
+
+    return QByteArray(data.getvalue())
+
+
+def test_response_plot_data(sweep, plot_duration=0.1, num_baseline_samples=100):
+
+    timestep = sweep.t[1] - sweep.t[0]
+    num_samples = int(plot_duration / timestep)
+
+    return (
+        sweep.t[0: num_samples], 
+        sweep.v[0: num_samples] - np.mean(sweep.v[0: num_baseline_samples])
+    )
+
+
+def make_test_pulse_plot(sweep_number, time, voltage, previous=None, initial=None):
+    
+    fig, ax = plt.subplots()
+
+    if initial is not None:
+        ax.plot(time, initial, linewidth=1, label=f"initial", color="green")
+        
+    if previous is not None:
+        ax.plot(time, previous, linewidth=1, label=f"previous", color="orange")
+    
+    ax.plot(time, voltage, linewidth=1, label=f"sweep {sweep_number}", color="blue")
+    return fig
+
+    
+def experiment_plot_data(sweep, bessel_num, bessel_denom):    
+
+    experiment_start_index, _ = get_experiment_epoch(sweep.i, sweep.sampling_rate)
+    if experiment_start_index <= 0:
+        experiment_start_index = 5000 # aaaaaaaaaaaaaaaaaaaaaaaaaaaah
+    
+    time = sweep.t[experiment_start_index:]
+    voltage = filtfilt(bessel_num, bessel_denom, sweep.v[experiment_start_index:], axis=0)
+    baseline_mean = np.mean(voltage[5000:9000]) # aaaaaaaaaaaaaaaaaaaaaaaaaaaah
+    
+    return time, voltage, baseline_mean
+
+
+def make_experiment_plot(exp_time, exp_voltage, exp_baseline):
+    time_lim = [exp_time[0], exp_time[-1]]
+
+    fig, ax = plt.subplots()
+
+    ax.plot(exp_time, exp_voltage, linewidth=1)
+    ax.hlines(exp_baseline, *time_lim, linewidth=1)
+    ax.set_xlim(time_lim)
+
+    return fig

--- a/src/main/python/sweep.py
+++ b/src/main/python/sweep.py
@@ -21,6 +21,10 @@ from delegates import (SvgDelegate, ComboBoxDelegate)
 from pre_fx_data import PreFxData
 
 
+PLOT_FONTSIZE = 24
+DEFAULT_FIGSIZE = (8, 8)
+
+
 class SweepPlotConfig(NamedTuple):
     test_plot_duration: float
     test_pulse_baseline_samples: int
@@ -29,6 +33,7 @@ class SweepPlotConfig(NamedTuple):
     experiment_baseline_end_index: int
     experiment_plot_bessel_order: int
     experiment_plot_bessel_critical_frequency: float
+
 
 class SweepTableModel(QAbstractTableModel):
 
@@ -118,10 +123,10 @@ class SweepTableModel(QAbstractTableModel):
                 self.plot_config.experiment_baseline_end_index
             )
 
-            test_pulse_plot = make_test_pulse_plot(sweep_number, test_time, 
-                test_voltage, previous_test_voltage, initial_test_voltage
+            test_pulse_plot = make_test_pulse_plot(
+                sweep_number, test_time, test_voltage, previous_test_voltage, initial_test_voltage
             )
-            experiment_plot = make_experiment_plot(exp_time, exp_voltage, exp_baseline)
+            experiment_plot = make_experiment_plot(sweep_number, exp_time, exp_voltage, exp_baseline)
 
             self._data.append([
                 sweep_number,
@@ -324,7 +329,7 @@ def test_response_plot_data(sweep, plot_duration=0.1, num_baseline_samples=100):
 
 def make_test_pulse_plot(sweep_number, time, voltage, previous=None, initial=None):
     
-    fig, ax = plt.subplots()
+    fig, ax = plt.subplots(figsize=DEFAULT_FIGSIZE)
 
     if initial is not None:
         ax.plot(time, initial, linewidth=1, label=f"initial", color="green")
@@ -333,6 +338,11 @@ def make_test_pulse_plot(sweep_number, time, voltage, previous=None, initial=Non
         ax.plot(time, previous, linewidth=1, label=f"previous", color="orange")
     
     ax.plot(time, voltage, linewidth=1, label=f"sweep {sweep_number}", color="blue")
+
+    ax.set_xlabel("time (s)", fontsize=PLOT_FONTSIZE)
+    ax.set_ylabel("membrane potential (V)", fontsize=PLOT_FONTSIZE)
+    ax.legend()
+
     return fig
 
     
@@ -356,13 +366,17 @@ def experiment_plot_data(
     return time, voltage, baseline_mean
 
 
-def make_experiment_plot(exp_time, exp_voltage, exp_baseline):
+def make_experiment_plot(sweep_number, exp_time, exp_voltage, exp_baseline):
     time_lim = [exp_time[0], exp_time[-1]]
 
-    fig, ax = plt.subplots()
+    fig, ax = plt.subplots(figsize=DEFAULT_FIGSIZE)
 
-    ax.plot(exp_time, exp_voltage, linewidth=1)
-    ax.hlines(exp_baseline, *time_lim, linewidth=1)
+    ax.plot(exp_time, exp_voltage, linewidth=1, label=f"sweep {sweep_number}")
+    ax.hlines(exp_baseline, *time_lim, linewidth=1, label="baseline")
     ax.set_xlim(time_lim)
+
+    ax.set_xlabel("time (s)", fontsize=PLOT_FONTSIZE)
+    ax.set_ylabel("membrane potential (V)", fontsize=PLOT_FONTSIZE)
+    ax.legend()
 
     return fig


### PR DESCRIPTION
addresses #13 and #14. 

- data loaded from nwb files is visible in sweep table
- edits made to manual qc state are propagated to undelying pre_fx_data
- edits made to manual qc state are saved when exporting to json
- sweep table displays test pulse and experiment plot thumbnails
- users can click on plot thumbnails for larger view

![sweep_qc_data](https://user-images.githubusercontent.com/15089451/69602860-c4a3c180-0fcd-11ea-948f-871162d1f201.png)
