### PR TITLE
handle truncated experiments

### DIFF
--- a/src/main/python/delegates.py
+++ b/src/main/python/delegates.py
@@ -21,7 +21,7 @@ class SvgDelegate(QStyledItemDelegate):
             option: QStyleOptionViewItem,
             index: QModelIndex
     ):
-        value = index.data()
+        value = index.data().thumbnail
 
         renderer = QSvgRenderer()
         renderer.load(value)

--- a/src/main/python/main.py
+++ b/src/main/python/main.py
@@ -177,7 +177,8 @@ class Application(object):
         test_plot_duration: float, 
         test_pulse_baseline_samples: int,
         experiment_plot_bessel_order: int,
-        experiment_plot_bessel_critical_frequency: float
+        experiment_plot_bessel_critical_frequency: float,
+        thumbnail_step: int
     ):
         self.app_cntxt = ApplicationContext()
 
@@ -188,7 +189,8 @@ class Application(object):
             experiment_baseline_start_index, 
             experiment_baseline_end_index,
             experiment_plot_bessel_order,
-            experiment_plot_bessel_critical_frequency
+            experiment_plot_bessel_critical_frequency,
+            thumbnail_step
         )
 
         # initialize components
@@ -229,7 +231,7 @@ if __name__ == '__main__':
     parser.add_argument("--experiment_baseline_start_index", type=int, default=5000,
         help="when plotting experiment pulses, where to start the baseline assessment epoch"
     )
-    parser.add_argument("--experiment_baseline_end_index", type=int, default=5000,
+    parser.add_argument("--experiment_baseline_end_index", type=int, default=9000,
         help="when plotting experiment pulses, where to end the baseline assessment epoch"
     )
     parser.add_argument("--test_plot_duration", type=float, default=0.1,
@@ -243,6 +245,9 @@ if __name__ == '__main__':
     )
     parser.add_argument("--experiment_plot_bessel_critical_frequency", type=float, default=0.1, 
         help="when plotting sweep voltage traces for the experiment epoch a lowpass bessel filter is applied to the trace. This parameter defines the critical frequency of that filter."
+    )
+    parser.add_argument("--thumbnail_step", type=float, default=300, 
+        help="step size for generating decimated thumbnail images for individual sweeps."
     )
     args = parser.parse_args()
 

--- a/src/main/python/pre_fx_data.py
+++ b/src/main/python/pre_fx_data.py
@@ -12,6 +12,7 @@ from ipfx.qc_feature_evaluator import qc_experiment, DEFAULT_QC_CRITERIA_FILE
 from ipfx.bin.run_qc import qc_summary
 from ipfx.stimulus import StimulusOntology, Stimulus
 from ipfx.data_set_utils import create_data_set
+from ipfx.sweep_props import drop_tagged_sweeps
 
 from error_handling import exception_message
 from marshmallow import ValidationError
@@ -299,6 +300,7 @@ def extract_qc_features(data_set):
         # manual_values=cell_qc_manual_values
     )
     sweep_features = sweep_qc_features(data_set)
+    drop_tagged_sweeps(sweep_features)
     return cell_features, cell_tags, sweep_features
 
 def run_qc(stimulus_ontology, cell_features, sweep_features, qc_criteria):

--- a/src/main/python/sweep.py
+++ b/src/main/python/sweep.py
@@ -390,7 +390,7 @@ def make_test_pulse_plot(sweep_number, time, voltage, previous=None, initial=Non
     ax.plot(time[::step], voltage[::step], linewidth=1, label=f"sweep {sweep_number}", color="blue")
 
     ax.set_xlabel("time (s)", fontsize=PLOT_FONTSIZE)
-    ax.set_ylabel("membrane potential (V)", fontsize=PLOT_FONTSIZE)
+    ax.set_ylabel("membrane potential (mV)", fontsize=PLOT_FONTSIZE)
 
     if labels:
         ax.legend()
@@ -434,7 +434,7 @@ def make_experiment_plot(sweep_number, exp_time, exp_voltage, exp_baseline, step
     ax.set_xlim(time_lim)
 
     ax.set_xlabel("time (s)", fontsize=PLOT_FONTSIZE)
-    ax.set_ylabel("membrane potential (V)", fontsize=PLOT_FONTSIZE)
+    ax.set_ylabel("membrane potential (mV)", fontsize=PLOT_FONTSIZE)
 
     if labels:
         ax.legend()

--- a/src/main/python/sweep.py
+++ b/src/main/python/sweep.py
@@ -416,10 +416,7 @@ def experiment_plot_data(
     time = sweep.t[experiment_start_index:]
     voltage = sweep.v[experiment_start_index:]
 
-    voltage_defined = ~np.isnan(voltage)
-
-    time = time[voltage_defined]
-    voltage = voltage[voltage_defined]
+    voltage[np.isnan(voltage)] = 0.0
 
     voltage = filtfilt(bessel_num, bessel_denom, voltage, axis=0)
     baseline_mean = np.nanmean(voltage[baseline_start_index: baseline_end_index])

--- a/src/main/python/sweep.py
+++ b/src/main/python/sweep.py
@@ -389,9 +389,10 @@ def make_test_pulse_plot(sweep_number, time, voltage, previous=None, initial=Non
     
     ax.plot(time[::step], voltage[::step], linewidth=1, label=f"sweep {sweep_number}", color="blue")
 
+    ax.set_xlabel("time (s)", fontsize=PLOT_FONTSIZE)
+    ax.set_ylabel("membrane potential (V)", fontsize=PLOT_FONTSIZE)
+
     if labels:
-        ax.set_xlabel("time (s)", fontsize=PLOT_FONTSIZE)
-        ax.set_ylabel("membrane potential (V)", fontsize=PLOT_FONTSIZE)
         ax.legend()
     else:
         ax.xaxis.set_major_locator(plt.NullLocator())
@@ -409,12 +410,12 @@ def experiment_plot_data(
     baseline_end_index: int = 9000
 ):    
 
-    experiment_start_index, _ = get_experiment_epoch(sweep.i, sweep.sampling_rate)
+    experiment_start_index, experiment_end_index = get_experiment_epoch(sweep.i, sweep.sampling_rate)
     if experiment_start_index <= 0:
         experiment_start_index = backup_start_index
     
-    time = sweep.t[experiment_start_index:]
-    voltage = sweep.v[experiment_start_index:]
+    time = sweep.t[experiment_start_index:experiment_end_index]
+    voltage = sweep.v[experiment_start_index:experiment_end_index]
 
     voltage[np.isnan(voltage)] = 0.0
 
@@ -432,9 +433,10 @@ def make_experiment_plot(sweep_number, exp_time, exp_voltage, exp_baseline, step
     ax.hlines(exp_baseline, *time_lim, linewidth=1, label="baseline")
     ax.set_xlim(time_lim)
 
+    ax.set_xlabel("time (s)", fontsize=PLOT_FONTSIZE)
+    ax.set_ylabel("membrane potential (V)", fontsize=PLOT_FONTSIZE)
+
     if labels:
-        ax.set_xlabel("time (s)", fontsize=PLOT_FONTSIZE)
-        ax.set_ylabel("membrane potential (V)", fontsize=PLOT_FONTSIZE)
         ax.legend()
     else:
         ax.xaxis.set_major_locator(plt.NullLocator())


### PR DESCRIPTION
Some sweeps seem to be truncated. This breaks loading and plotting.

This pr:
- handles truncated sweeps
- improves responsiveness of the table view by displaying small plot thumbnails, which can be clicked on for larger detailed plots.