### PR TITLE
[WIP] Add slot onActivated which would set current index and commit data

### DIFF
--- a/src/main/python/delegates.py
+++ b/src/main/python/delegates.py
@@ -44,6 +44,7 @@ class ComboBoxDelegate(QItemDelegate):
     def createEditor(self, parent, option, index):
         self.editor = QComboBox(parent)
         self.editor.addItems(self.items)
+        self.editor.activated.connect(self.onActivated)
         return self.editor
 
     def paint(self, painter, option, index):
@@ -55,14 +56,24 @@ class ComboBoxDelegate(QItemDelegate):
         style.drawComplexControl(QStyle.CC_ComboBox, opt, painter)
         QItemDelegate.paint(self, painter, option, index)
 
+    def onActivated(self, index):
+        print(f" received index change {index} ")
+        self.editor.setCurrentIndex(index)
+        print(f" current text {self.editor.currentText()} and index {self.editor.currentIndex()}")
+
+        self.commitData.emit(self.editor)   # this does not help because index was not updated inside editor
+        self.closeEditor.emit(self.editor)
+
     def setEditorData(self, editor, index):
         value = index.data(QtCore.Qt.DisplayRole)
         num = self.items.index(value)
         editor.setCurrentIndex(num)
 
+
     def setModelData(self, editor, model, index):
         value = editor.currentText()
         model.setData(index, value, QtCore.Qt.EditRole)
+        print(f"model data changed: {index.data()} {value}")
 
     def updateEditorGeometry(self, editor, option, index):
         editor.setGeometry(option.rect)

--- a/src/main/python/delegates.py
+++ b/src/main/python/delegates.py
@@ -42,10 +42,12 @@ class ComboBoxDelegate(QItemDelegate):
         self.items = choices
 
     def createEditor(self, parent, option, index):
-        self.editor = QComboBox(parent)
-        self.editor.addItems(self.items)
-        self.editor.activated.connect(self.onActivated)
-        return self.editor
+
+        editor = QComboBox(parent)
+        editor.addItems(self.items)
+        editor.activated.connect(self.onActivated)
+
+        return editor
 
     def paint(self, painter, option, index):
         value = index.data(QtCore.Qt.DisplayRole)
@@ -56,9 +58,19 @@ class ComboBoxDelegate(QItemDelegate):
         style.drawComplexControl(QStyle.CC_ComboBox, opt, painter)
         QItemDelegate.paint(self, painter, option, index)
 
-    def onActivated(self, index):
+    def onActivated(self):
+        """ Triggered when the user makes a selection. When that occurs, focus 
+        is removed from the editing combobox, which in turn causes 
+        setModelData to be called on this delegate.
+        """
+
         app = QApplication.instance()
-        app.focusWidget().clearFocus()
+
+        sender = app.sender()
+        focus = app.focusWidget()
+
+        if sender is focus:
+            focus.clearFocus()
 
     def setEditorData(self, editor, index):
         value = index.data(QtCore.Qt.DisplayRole)

--- a/src/main/python/delegates.py
+++ b/src/main/python/delegates.py
@@ -57,23 +57,17 @@ class ComboBoxDelegate(QItemDelegate):
         QItemDelegate.paint(self, painter, option, index)
 
     def onActivated(self, index):
-        print(f" received index change {index} ")
-        self.editor.setCurrentIndex(index)
-        print(f" current text {self.editor.currentText()} and index {self.editor.currentIndex()}")
-
-        self.commitData.emit(self.editor)   # this does not help because index was not updated inside editor
-        self.closeEditor.emit(self.editor)
+        app = QApplication.instance()
+        app.focusWidget().clearFocus()
 
     def setEditorData(self, editor, index):
         value = index.data(QtCore.Qt.DisplayRole)
         num = self.items.index(value)
         editor.setCurrentIndex(num)
 
-
     def setModelData(self, editor, model, index):
         value = editor.currentText()
         model.setData(index, value, QtCore.Qt.EditRole)
-        print(f"model data changed: {index.data()} {value}")
 
     def updateEditorGeometry(self, editor, option, index):
         editor.setGeometry(option.rect)

--- a/src/main/python/fx_data.py
+++ b/src/main/python/fx_data.py
@@ -38,7 +38,7 @@ class FxData(QObject):
         self.ontology = ontology
         self.sweep_info = sweep_info
         self.cell_info = cell_info
-        print("set fx parameters")
+
     def connect(self, pre_fx_data):
         pre_fx_data.data_changed.connect(self.set_fx_parameters)
 

--- a/src/main/python/fx_data.py
+++ b/src/main/python/fx_data.py
@@ -38,7 +38,7 @@ class FxData(QObject):
         self.ontology = ontology
         self.sweep_info = sweep_info
         self.cell_info = cell_info
-
+        print("set fx parameters")
     def connect(self, pre_fx_data):
         pre_fx_data.data_changed.connect(self.set_fx_parameters)
 

--- a/src/test/test_delegates.py
+++ b/src/test/test_delegates.py
@@ -1,0 +1,31 @@
+import pytest
+
+from PyQt5.QtWidgets import QComboBox, QApplication, QMainWindow
+from PyQt5.QtCore import Qt
+
+import numpy as np
+
+from delegates import ComboBoxDelegate
+
+
+def test_combobox_activated(qtbot):
+
+    record = []
+    def set_record(_, b):
+        record.append(b)
+
+    delegate = ComboBoxDelegate(None, ["a", "b", "c"])
+    delegate.setModelData = set_record
+
+    dummy = QMainWindow()
+    cb = delegate.createEditor(dummy, None, None)
+    qtbot.addWidget(cb)
+
+    app = QApplication.instance()
+    app.setActiveWindow(dummy)
+    cb.setFocus()
+
+    cb.activated.emit(12)
+
+    assert app.focusWidget() is None
+    assert np.allclose(record, [12])


### PR DESCRIPTION
Without this setModelData does not get activated untill a click outside
of combobox.

I left the print statements to demonstrate signal propagation.
Resolve #30 
I am not entire happy with this implementation largely because I am not sure why setModelData would not activate on first click. Also, seems like I should not be manually setting the index. This should be the job of the combobox.

Relevant discussions:
https://www.qtcentre.org/threads/59244-Changing-index-in-combobox-delegate-only-calls-setModelData-after-losing-focus

https://forum.qt.io/topic/4435/qabstractitemdelegate-and-editing/8